### PR TITLE
more correct MaterialProgressDrawable.isRunning() implementation

### DIFF
--- a/materialloadingprogressbar/src/main/java/com/lsjwzh/widget/materialloadingprogressbar/MaterialProgressDrawable.java
+++ b/materialloadingprogressbar/src/main/java/com/lsjwzh/widget/materialloadingprogressbar/MaterialProgressDrawable.java
@@ -273,7 +273,7 @@ public class MaterialProgressDrawable extends Drawable implements Animatable {
 
     @Override
     public boolean isRunning() {
-        return  !this.mAnimation.hasEnded();
+        return this.mAnimation.hasStarted() && !this.mAnimation.hasEnded();
     }
 
     @Override


### PR DESCRIPTION
This change fixes sporadic "Progress background is shown, but animated circle does not appear" issue.
