### PR TITLE
fix bug: if the view has animation, it can't be removed by parent actually. 

### DIFF
--- a/materialloadingprogressbar/src/main/java/com/lsjwzh/widget/materialloadingprogressbar/CircleProgressBar.java
+++ b/materialloadingprogressbar/src/main/java/com/lsjwzh/widget/materialloadingprogressbar/CircleProgressBar.java
@@ -380,6 +380,8 @@ public class CircleProgressBar extends ImageView {
         if (mProgressDrawable != null) {
             mProgressDrawable.stop();
             mProgressDrawable.setVisible(getVisibility() == VISIBLE, false);
+
+            requestLayout();
         }
     }
 

--- a/materialloadingprogressbar/src/main/java/com/lsjwzh/widget/materialloadingprogressbar/MaterialProgressDrawable.java
+++ b/materialloadingprogressbar/src/main/java/com/lsjwzh/widget/materialloadingprogressbar/MaterialProgressDrawable.java
@@ -359,6 +359,10 @@ public class MaterialProgressDrawable extends Drawable implements Animatable {
                     float groupRotation = ((720.0f / NUM_POINTS) * interpolatedTime)
                             + (720.0f * (mRotationCount / NUM_POINTS));
                     setRotation(groupRotation);
+
+                    // If this view is removed by parent
+                    // clear the anim
+                    if ( mAnimExcutor.getParent() == null ) stop();
                 }
             }
         };


### PR DESCRIPTION
fix bug: if the view has animation, it can't be removed by parent actually.

fix bug: if the CircleProgressBar has a container, if the container is removed by it's parent and add back again, the animation will nerver start again.
